### PR TITLE
Track more booleans

### DIFF
--- a/stats/dashboard.py
+++ b/stats/dashboard.py
@@ -535,10 +535,12 @@ class ActivityStats(CommonSharedElements):
     def boolean_values(self):
         out = defaultdict(lambda: defaultdict(int))
         for path in [
+		'reporting-org/@secondary-reporter',
                 'result/indicator/@ascending',
                 'result/@aggregation-status',
                 'conditions/@attached',
                 'crs-add/aidtype-flag/@significance',
+		'crs-add/other-flags/@significance',
                 'fss/@priority',
                 '@humanitarian',
                 'transaction/@humanitarian'

--- a/stats/dashboard.py
+++ b/stats/dashboard.py
@@ -535,14 +535,14 @@ class ActivityStats(CommonSharedElements):
     def boolean_values(self):
         out = defaultdict(lambda: defaultdict(int))
         for path in [
-		'reporting-org/@secondary-reporter',
-                'result/indicator/@ascending',
-                'result/@aggregation-status',
                 'conditions/@attached',
                 'crs-add/aidtype-flag/@significance',
 		'crs-add/other-flags/@significance',
                 'fss/@priority',
                 '@humanitarian',
+		'reporting-org/@secondary-reporter',
+                'result/indicator/@ascending',
+                'result/@aggregation-status',
                 'transaction/@humanitarian'
                 ]:
             for value in self.element.xpath(path):

--- a/stats/dashboard.py
+++ b/stats/dashboard.py
@@ -537,10 +537,10 @@ class ActivityStats(CommonSharedElements):
         for path in [
                 'conditions/@attached',
                 'crs-add/aidtype-flag/@significance',
-		'crs-add/other-flags/@significance',
+                'crs-add/other-flags/@significance',
                 'fss/@priority',
                 '@humanitarian',
-		'reporting-org/@secondary-reporter',
+                'reporting-org/@secondary-reporter',
                 'result/indicator/@ascending',
                 'result/@aggregation-status',
                 'transaction/@humanitarian'


### PR DESCRIPTION
This adds more booleans from the [Activity Standard Summary Table](http://iatistandard.org/202/activity-standard/summary-table/) to track. All booleans in this table are now tracked.