### PR TITLE
Test to see whether tests need whitelisting

### DIFF
--- a/statsrunner/gitaggregate.py
+++ b/statsrunner/gitaggregate.py
@@ -30,7 +30,8 @@ whitelisted_stats_files = [
     'publishers_validation',
     'unique_identifiers',
     'validation',
-    'versions'
+    'versions',
+    'teststat'
     ]
 
 # Load the reference of commits to dates 


### PR DESCRIPTION
In changing from a blacklist to a whitelist, the custom file used in tests was not added to the whitelist.

This adds it to the whitelist.