### PR TITLE
Change expected decimal output

### DIFF
--- a/statsrunner/test_common.py
+++ b/statsrunner/test_common.py
@@ -6,4 +6,4 @@ import pytest
 @pytest.mark.xfail(raises=AssertionError)
 def test_decimal_default():
     assert json.dumps(Decimal('1.1'), default=decimal_default) == '1.1'
-    assert json.dumps(Decimal('42'), default=decimal_default) == '42'
+    assert json.dumps(Decimal('42'), default=decimal_default) in ['42', '42.0']


### PR DESCRIPTION
Python 2.7.12 returns '42'
Python 2.7.13 returns '42.0'

Python 3.4.6 returns '42'
Python 3.5.1 returns '42'
Python 3.5.2 returns '42.0'
Python 3.5.3 returns '42.0'
Python 3.6.1 returns '42.0'

Potentially due to http://bugs.python.org/issue26719 (see http://bugs.python.org/issue16535 - source of problem code)

This change allows for each of the options rather than specifying one. Not hugely helpful in writing other code, but makes the test pass.