### PR TITLE
Add support for IATI version 2.03

### DIFF
--- a/helpers/get_codelist_mapping.sh
+++ b/helpers/get_codelist_mapping.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 wget https://raw.github.com/IATI/IATI-Codelists/version-1.05/mapping.xml -O mapping-1.xml
-wget https://raw.github.com/IATI/IATI-Codelists/version-2.02/mapping.xml -O mapping-2.xml
+wget https://raw.github.com/IATI/IATI-Codelists/version-2.03/mapping.xml -O mapping-2.xml

--- a/helpers/get_schemas.sh
+++ b/helpers/get_schemas.sh
@@ -2,7 +2,7 @@
 
 mkdir schemas
 cd schemas
-for v in 1.01 1.02 1.03 1.04 1.05 2.01 2.02; do
+for v in 1.01 1.02 1.03 1.04 1.05 2.01 2.02 2.03; do
     git clone https://github.com/IATI/IATI-Schemas.git $v
     cd $v
     git checkout version-$v


### PR DESCRIPTION
# DO NOT MERGE UNTIL IATI VERSION 2.03 IS LIVE: http://iatistandard.org/202/upgrades/decimal-upgrade-to-2-03/

Refs #117 


## Tasks to complete after merging:

- [ ] Both get_schemas.sh and get_codelist_mapping.sh need running on the dev server
- [ ] Once at least one generation is made, the code can be deployed to the live server and both scripts run