### PR TITLE
Update test_generic_file_stats.py

### DIFF
--- a/stats/tests/test_generic_file_stats.py
+++ b/stats/tests/test_generic_file_stats.py
@@ -6,7 +6,7 @@ import pytest
 from stats.dashboard import ActivityStats
 
 
-@pytest.mark.parametrize('version', ['1.01', '1.02', '1.03', '1.04', '1.05', '2.01', '2.02'])
+@pytest.mark.parametrize('version', ['1.01', '1.02', '1.03', '1.04', '1.05', '2.01', '2.02', '2.03'])
 def test_version_detection_valid(version):
     """
     Tests that valid versions of the IATI Standard are detected.
@@ -26,7 +26,7 @@ def test_version_detection_valid(version):
     assert activity._version() == version
 
 
-@pytest.mark.parametrize('version', ['1.06', '2.03', '3.01', '1', '', 'version 1.03', '1.03 version', '1.03 or 1.04', ' 2.01', '2 .01'])
+@pytest.mark.parametrize('version', ['1.06', '2.04', '3.01', '1', '', 'version 1.03', '1.03 version', '1.03 or 1.04', ' 2.01', '2 .01'])
 def test_version_detection_invalid(version):
     """
     Tests that invalid versions of the IATI Standard are detected.


### PR DESCRIPTION
Change 2.03 from an invalid to a valid version.

2.04 is now specified as an invalid version.