### PR TITLE
Disable ruleset tests

### DIFF
--- a/stats/dashboard.py
+++ b/stats/dashboard.py
@@ -389,7 +389,7 @@ class CommonSharedElements(object):
             return '1.01'
 
     @returns_numberdict
-    def ruleset_passes(self):
+    def _ruleset_passes(self):
         out = {}
         for ruleset_name in ['standard']:
             ruleset = json.load(open('helpers/rulesets/{0}.json'.format(ruleset_name)), object_pairs_hook=OrderedDict)


### PR DESCRIPTION
Profiling suggests this test is one of the slowest. It doesn’t appear to be used by the dashboard anyway. So disabling it should speed things up a bit, without causing issues for the dashboard.

Refs #129.