### PR TITLE
Revert “Include activities using `humanitarian-scope` in number of activities”

### DIFF
--- a/stats/dashboard.py
+++ b/stats/dashboard.py
@@ -1209,8 +1209,6 @@ class ActivityStats(CommonSharedElements):
         is_not_humanitarian_by_attrib_transaction = 1 if not is_humanitarian_by_attrib_transaction and set(self.element.xpath('transaction/@humanitarian')).intersection(['0', 'false']) else 0
         is_humanitarian_by_attrib = (self._version() in ['2.02', '2.03']) and (is_humanitarian_by_attrib_activity or (is_humanitarian_by_attrib_transaction and not is_not_humanitarian_by_attrib_activity))
 
-        is_humanitarian_by_scope = (self._version() in ['2.02', '2.03']) and (self.element.xpath('humanitarian-scope') != [])
-
         # logic around DAC sector codes deemed to be humanitarian
         is_humanitarian_by_sector_5_digit_activity = 1 if set(self.element.xpath('sector[@vocabulary="{0}" or not(@vocabulary)]/@code'.format(self._dac_5_code()))).intersection(humanitarian_sectors_dac_5_digit) else 0
         is_humanitarian_by_sector_5_digit_transaction = 1 if set(self.element.xpath('transaction[not(@humanitarian="0" or @humanitarian="false")]/sector[@vocabulary="{0}" or not(@vocabulary)]/@code'.format(self._dac_5_code()))).intersection(humanitarian_sectors_dac_5_digit) else 0
@@ -1222,7 +1220,7 @@ class ActivityStats(CommonSharedElements):
         is_humanitarian_by_sector = is_humanitarian_by_sector_activity or (is_humanitarian_by_sector_transaction and (self._major_version() in ['2']))
 
         # combine the various ways in which an activity may be humanitarian
-        is_humanitarian = 1 if (is_humanitarian_by_attrib or is_humanitarian_by_scope or is_humanitarian_by_sector) else 0
+        is_humanitarian = 1 if (is_humanitarian_by_attrib or is_humanitarian_by_sector) else 0
         # deal with some edge cases that have veto
         if is_not_humanitarian_by_attrib_activity:
             is_humanitarian = 0
@@ -1230,7 +1228,7 @@ class ActivityStats(CommonSharedElements):
         return {
             'is_humanitarian': is_humanitarian,
             'is_humanitarian_by_attrib': is_humanitarian_by_attrib,
-            'contains_humanitarian_scope': 1 if is_humanitarian_by_scope and self.element.xpath('humanitarian-scope/@type') and self.element.xpath('humanitarian-scope/@code') else 0,
+            'contains_humanitarian_scope': 1 if (self._version() in ['2.02', '2.03']) and self.element.xpath('humanitarian-scope/@type') and self.element.xpath('humanitarian-scope/@code') else 0,
             'uses_humanitarian_clusters_vocab': 1 if (self._version() in ['2.02', '2.03']) and self.element.xpath('sector/@vocabulary="10"') else 0
         }
 

--- a/stats/tests/test_humanitarian.py
+++ b/stats/tests/test_humanitarian.py
@@ -619,10 +619,7 @@ def test_humanitarian_scope_valid(version):
            <humanitarian-scope type="" code="" />
         </iati-activity>
     ''')
-    assert activity_stats.humanitarian()['is_humanitarian'] == 1
-    assert activity_stats.humanitarian()['is_humanitarian_by_attrib'] == 0
     assert activity_stats.humanitarian()['contains_humanitarian_scope'] == 1
-    assert activity_stats.humanitarian()['uses_humanitarian_clusters_vocab'] == 0
 
 
 @pytest.mark.parametrize('version', ['2.02', '2.03'])
@@ -637,10 +634,7 @@ def test_humanitarian_scope_invalid(version):
            <humanitarian-scope />
         </iati-activity>
     ''')
-    assert activity_stats.humanitarian()['is_humanitarian'] == 1
-    assert activity_stats.humanitarian()['is_humanitarian_by_attrib'] == 0
     assert activity_stats.humanitarian()['contains_humanitarian_scope'] == 0
-    assert activity_stats.humanitarian()['uses_humanitarian_clusters_vocab'] == 0
 
 
 @pytest.mark.parametrize('version', ['2.02', '2.03'])


### PR DESCRIPTION
#130 wasn’t quite right! The code prior to #130 was **correct**; it’s the definition that was wrong (and needs revising).

This is confirmed in https://github.com/IATI/IATI-Dashboard/issues/485#issuecomment-396901278