### PR TITLE
Update folder name for latest IATI version

### DIFF
--- a/helpers/get_codelists.sh
+++ b/helpers/get_codelists.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-for x in 105 202; do
+for x in 105 203; do
     i=$(echo $x | head -c 1)
     mkdir -p codelists/$i
     wget "http://iatistandard.org/$x/codelists/downloads/clv2/json/en/Version.json" -O codelists/$i/Version.json


### PR DESCRIPTION
Changes folder name to reference IATI v2.03 which was released in February 2018. This change appears to have slipped through the cracks of #118