### PR TITLE
Adding budget-not-provided to comprehensiveness tables

### DIFF
--- a/get_stats.sh
+++ b/get_stats.sh
@@ -3,7 +3,7 @@ set -e
 
 mkdir gitout
 for f in ckan gitdate; do
-    curl --compress "http://dashboard.iatistandard.org/stats/${f}.json" > gitout/${f}.json
+    curl --compressed "http://dashboard.iatistandard.org/stats/${f}.json" > gitout/${f}.json
 done
 
 mkdir stats-blacklist

--- a/helpers/get_codelists.sh
+++ b/helpers/get_codelists.sh
@@ -10,4 +10,5 @@ for x in 105 203; do
     wget "http://iatistandard.org/$x/codelists/downloads/clv2/json/en/SectorCategory.json" -O codelists/$i/SectorCategory.json
     wget "http://iatistandard.org/$x/codelists/downloads/clv2/json/en/DocumentCategory.json" -O codelists/$i/DocumentCategory.json
     wget "http://iatistandard.org/$x/codelists/downloads/clv2/json/en/AidType.json" -O codelists/$i/AidType.json
+    wget "http://iatistandard.org/$x/codelists/downloads/clv2/json/en/BudgetNotProvided.json" -O codelists/$i/BudgetNotProvided.json
 done

--- a/stats/dashboard.py
+++ b/stats/dashboard.py
@@ -1006,10 +1006,10 @@ class ActivityStats(CommonSharedElements):
             return True if textFound else False
 
         return {
-            'version': (self.element.getparent() is not None
-                        and 'version' in self.element.getparent().attrib),
-            'reporting-org': (self.element.xpath('reporting-org/@ref')
-                        and is_text_in_element('reporting-org')),
+            'version': (self.element.getparent() is not None and
+                        'version' in self.element.getparent().attrib),
+            'reporting-org': (self.element.xpath('reporting-org/@ref') and
+                        is_text_in_element('reporting-org')),
             'iati-identifier': self.element.xpath('iati-identifier/text()'),
             'participating-org': self.element.find('participating-org') is not None,
             'title': is_text_in_element('title'),
@@ -1021,9 +1021,9 @@ class ActivityStats(CommonSharedElements):
                         for transaction in self.element.findall('transaction')
                 )),
             'country_or_region': (
-                self.element.find('recipient-country') is not None
-                or self.element.find('recipient-region') is not None
-                or (self._major_version() != '1' and all_true_and_not_empty(
+                self.element.find('recipient-country') is not None or
+                self.element.find('recipient-region') is not None or
+                (self._major_version() != '1' and all_true_and_not_empty(
                     (transaction.find('recipient-country') is not None or
                      transaction.find('recipient-region') is not None)
                         for transaction in self.element.findall('transaction')
@@ -1031,8 +1031,8 @@ class ActivityStats(CommonSharedElements):
             'transaction_commitment': self.element.xpath('transaction[transaction-type/@code="{}" or transaction-type/@code="11"]'.format(self._commitment_code())),
             'transaction_spend': self.element.xpath('transaction[transaction-type/@code="{}" or transaction-type/@code="{}"]'.format(self._disbursement_code(), self._expenditure_code())),
             'transaction_currency': all_true_and_not_empty(x.xpath('value/@value-date') and x.xpath('../@default-currency|./value/@currency') for x in self.element.findall('transaction')),
-            'transaction_traceability': all_true_and_not_empty(x.xpath('provider-org/@provider-activity-id') for x in self.element.xpath('transaction[transaction-type/@code="{}"]'.format(self._incoming_funds_code())))
-                                        or self._is_donor_publisher(),
+            'transaction_traceability': all_true_and_not_empty(x.xpath('provider-org/@provider-activity-id') for x in self.element.xpath('transaction[transaction-type/@code="{}"]'.format(self._incoming_funds_code()))) or
+                                        self._is_donor_publisher(),
             'budget': (
                 self.element.findall('budget') or
                 self._budget_not_provided() is not None),
@@ -1047,8 +1047,8 @@ class ActivityStats(CommonSharedElements):
             'conditions_attached': self.element.xpath('conditions/@attached'),
             'result_indicator': self.element.xpath('result/indicator'),
             'aid_type': (
-                all_true_and_not_empty(self.element.xpath('default-aid-type/@code'))
-                or all_true_and_not_empty([transaction.xpath('aid-type/@code') for transaction in self.element.xpath('transaction')])
+                all_true_and_not_empty(self.element.xpath('default-aid-type/@code')) or
+                all_true_and_not_empty([transaction.xpath('aid-type/@code') for transaction in self.element.xpath('transaction')])
                 )
             # Alternative: all(map(all_true_and_not_empty, [transaction.xpath('aid-type/@code') for transaction in self.element.xpath('transaction')]))
         }
@@ -1068,7 +1068,7 @@ class ActivityStats(CommonSharedElements):
     def _comprehensiveness_with_validation_bools(self):
 
             def element_ref(element_obj):
-                """Get the ref attribute of a given element
+                """Get the ref attribute of a given element.
 
                 Returns:
                   Value in the 'ref' attribute or None if none found
@@ -1100,8 +1100,6 @@ class ActivityStats(CommonSharedElements):
                             for es in elements_by_vocab.values())
                     else:
                         return len(elements) == 1 or sum(decimal_or_zero(x.attrib.get('percentage')) for x in elements) == 100
-            if(self._budget_not_provided()):
-                import pdb; pdb.set_trace()
             bools.update({
                 'version': bools['version'] and self.element.getparent().attrib['version'] in CODELISTS[self._major_version()]['Version'],
                 'iati-identifier': (
@@ -1147,8 +1145,7 @@ class ActivityStats(CommonSharedElements):
                             valid_date(budget.find('value')) and
                             valid_value(budget.find('value'))
                             for budget in bools['budget']) or
-                        (not (len(self.element.findall('budget')) > 0) and
-                        str(self._budget_not_provided()) in CODELISTS[self._major_version()]['BudgetNotProvided']))),
+                        (len(self.element.findall('budget')) == 0))),
                 'location_point_pos': all_true_and_not_empty(
                     valid_coords(x.text) for x in bools['location_point_pos']),
                 'sector_dac': (

--- a/stats/dashboard.py
+++ b/stats/dashboard.py
@@ -413,7 +413,7 @@ class ActivityStats(CommonSharedElements):
         return {self.element.attrib.get('hierarchy'):1}
 
     def _budget_not_provided(self):
-        if self.element.attrib.get('budget-not-provided'):
+        if self.element.attrib.get('budget-not-provided') is not Noneb:
             return int(self.element.attrib.get('budget-not-provided'))
         else:
             return None
@@ -897,8 +897,8 @@ class ActivityStats(CommonSharedElements):
     def forwardlooking_activities_with_budget_not_provided(self, date_code_runs=None):
         date_code_runs = date_code_runs if date_code_runs else self.now.date()
         this_year = int(date_code_runs.year)
-        bnp = self._budget_not_provided() is not None
-        return {year: int(self._forwardlooking_is_current(year) and bnp and not bool(self._forwardlooking_exclude_in_calculations(year=year, date_code_runs=date_code_runs)))
+        bnp = self._budget_not_provided() is not None 
+        return {year: int(self._forwardlooking_is_current(year) and bnp > 0 and not bool(self._forwardlooking_exclude_in_calculations(year=year, date_code_runs=date_code_runs)))
                 for year in range(this_year, this_year+3)}
 
     @memoize
@@ -1100,7 +1100,8 @@ class ActivityStats(CommonSharedElements):
                             for es in elements_by_vocab.values())
                     else:
                         return len(elements) == 1 or sum(decimal_or_zero(x.attrib.get('percentage')) for x in elements) == 100
-
+            if(self._budget_not_provided()):
+                import pdb; pdb.set_trace()
             bools.update({
                 'version': bools['version'] and self.element.getparent().attrib['version'] in CODELISTS[self._major_version()]['Version'],
                 'iati-identifier': (
@@ -1147,7 +1148,7 @@ class ActivityStats(CommonSharedElements):
                             valid_value(budget.find('value'))
                             for budget in bools['budget']) or
                         (not (len(self.element.findall('budget')) > 0) and
-                        self._budget_not_provided() in CODELISTS[self._major_version()]['BudgetNotProvided']))),
+                        str(self._budget_not_provided()) in CODELISTS[self._major_version()]['BudgetNotProvided']))),
                 'location_point_pos': all_true_and_not_empty(
                     valid_coords(x.text) for x in bools['location_point_pos']),
                 'sector_dac': (

--- a/stats/dashboard.py
+++ b/stats/dashboard.py
@@ -413,7 +413,7 @@ class ActivityStats(CommonSharedElements):
         return {self.element.attrib.get('hierarchy'):1}
 
     def _budget_not_provided(self):
-        if self.element.attrib.get('budget-not-provided') is not Noneb:
+        if self.element.attrib.get('budget-not-provided') is not None:
             return int(self.element.attrib.get('budget-not-provided'))
         else:
             return None
@@ -1145,7 +1145,8 @@ class ActivityStats(CommonSharedElements):
                             valid_date(budget.find('value')) and
                             valid_value(budget.find('value'))
                             for budget in bools['budget']) or
-                        (len(self.element.findall('budget')) == 0))),
+                        ((len(self.element.findall('budget')) == 0) and
+                        self._budget_not_provided() is not None))),
                 'location_point_pos': all_true_and_not_empty(
                     valid_coords(x.text) for x in bools['location_point_pos']),
                 'sector_dac': (

--- a/stats/tests/test_budget_not_provided.py
+++ b/stats/tests/test_budget_not_provided.py
@@ -1,7 +1,13 @@
+import json
 from lxml import etree
 
 from collections import defaultdict, OrderedDict
 from stats.common.decorators import *
+
+
+CODELISTS = {'1':{}, '2':{}}
+for major_version in ['1', '2']:
+    CODELISTS[major_version]['BudgetNotProvided'] = set(c['code'] for c in json.load(open('../../helpers/codelists/{}/{}.json'.format(major_version, 'BudgetNotProvided')))['data'])
 
 def test_budget_not_provided_works():
     activity_stats = ActivityStats()
@@ -17,16 +23,17 @@ def test_budget_not_provided_fails():
             <iati-activity>
             </iati-activity>
     ''')
-    assert activity_stats._budget_not_provided() == None
+    assert activity_stats._budget_not_provided() is None
 
 def test_budget_validation_bools():
     activity_stats = ActivityStats()
     activity_stats.element = etree.fromstring('''
             <iati-activity budget-not-provided="3">
-                <budget></budget>
             </iati-activity>
     ''')
-    assert not (len(activity_stats.element.findall('budget'))>0) == False
+    assert (not (len(activity_stats.element.findall('budget')) > 0) and str(activity_stats._budget_not_provided()) in CODELISTS['2']['BudgetNotProvided'])
+
+
 
 class CommonSharedElements(object):
     blank = False

--- a/stats/tests/test_budget_not_provided.py
+++ b/stats/tests/test_budget_not_provided.py
@@ -1,13 +1,8 @@
-import json
 from lxml import etree
 
 from collections import defaultdict, OrderedDict
 from stats.common.decorators import *
 
-
-CODELISTS = {'1':{}, '2':{}}
-for major_version in ['1', '2']:
-    CODELISTS[major_version]['BudgetNotProvided'] = set(c['code'] for c in json.load(open('../../helpers/codelists/{}/{}.json'.format(major_version, 'BudgetNotProvided')))['data'])
 
 def test_budget_not_provided_works():
     activity_stats = ActivityStats()
@@ -33,7 +28,7 @@ def test_budget_validation_bools():
             <iati-activity budget-not-provided="3">
             </iati-activity>
     ''')
-    assert (not (len(activity_stats.element.findall('budget')) > 0) and str(activity_stats._budget_not_provided()) in CODELISTS['2']['BudgetNotProvided'])
+    assert (len(activity_stats.element.findall('budget')) == 0)
 
 
 

--- a/stats/tests/test_budget_not_provided.py
+++ b/stats/tests/test_budget_not_provided.py
@@ -9,7 +9,7 @@ def test_budget_not_provided_works():
             <iati-activity budget-not-provided="1">
             </iati-activity>
     ''')
-    assert activity_stats._budget_not_provided() == {'budget-not-provided': '1'}
+    assert activity_stats._budget_not_provided() == 1
 
 def test_budget_not_provided_fails():
     activity_stats = ActivityStats()
@@ -17,16 +17,7 @@ def test_budget_not_provided_fails():
             <iati-activity>
             </iati-activity>
     ''')
-    assert activity_stats._budget_not_provided() == {'budget-not-provided': '0'}
-
-def test_budget_not_provided_value():
-    activity_stats = ActivityStats()
-    activity_stats.element = etree.fromstring('''
-            <iati-activity budget-not-provided="1">
-            </iati-activity>
-    ''')
-    assert int(activity_stats._budget_not_provided().values()[0]) == 1
-
+    assert activity_stats._budget_not_provided() == None
 
 class CommonSharedElements(object):
     blank = False
@@ -43,6 +34,6 @@ class ActivityStats(CommonSharedElements):
 
     def _budget_not_provided(self):
         if self.element.attrib.get('budget-not-provided'):
-            return {'budget-not-provided': self.element.attrib.get('budget-not-provided')}
+            return int(self.element.attrib.get('budget-not-provided'))
         else:
-            return {'budget-not-provided': '0'}
+            return None

--- a/stats/tests/test_budget_not_provided.py
+++ b/stats/tests/test_budget_not_provided.py
@@ -19,6 +19,15 @@ def test_budget_not_provided_fails():
     ''')
     assert activity_stats._budget_not_provided() == None
 
+def test_budget_validation_bools():
+    activity_stats = ActivityStats()
+    activity_stats.element = etree.fromstring('''
+            <iati-activity budget-not-provided="3">
+                <budget></budget>
+            </iati-activity>
+    ''')
+    assert not (len(activity_stats.element.findall('budget'))>0) == False
+
 class CommonSharedElements(object):
     blank = False
 

--- a/stats/tests/test_budget_not_provided.py
+++ b/stats/tests/test_budget_not_provided.py
@@ -17,6 +17,7 @@ def test_budget_not_provided_works():
     ''')
     assert activity_stats._budget_not_provided() == 1
 
+
 def test_budget_not_provided_fails():
     activity_stats = ActivityStats()
     activity_stats.element = etree.fromstring('''
@@ -24,6 +25,7 @@ def test_budget_not_provided_fails():
             </iati-activity>
     ''')
     assert activity_stats._budget_not_provided() is None
+
 
 def test_budget_validation_bools():
     activity_stats = ActivityStats()


### PR DESCRIPTION
Addressing [issue 455](https://github.com/IATI/IATI-Dashboard/issues/455) on the dashboard, still needs some revision on the `BudgetNotProvided` codelists for `comprehensiveness_with_validation`. 