### PR TITLE
Update tests and document forwardlooking_budget_not_provided()

### DIFF
--- a/stats/dashboard.py
+++ b/stats/dashboard.py
@@ -895,9 +895,17 @@ class ActivityStats(CommonSharedElements):
 
     @returns_numberdict
     def forwardlooking_activities_with_budget_not_provided(self, date_code_runs=None):
+        """
+        Number of activities with the budget_not_provided attribute for this year and the following 2 years.
+
+        Activities will be excluded if
+         i)  They end in the next 6 months
+         ii) At least 90% of the commitment transactions has been disbursed or expended
+             within or before the input year
+        """
         date_code_runs = date_code_runs if date_code_runs else self.now.date()
         this_year = int(date_code_runs.year)
-        bnp = self._budget_not_provided() is not None 
+        bnp = self._budget_not_provided() is not None
         return {year: int(self._forwardlooking_is_current(year) and bnp > 0 and not bool(self._forwardlooking_exclude_in_calculations(year=year, date_code_runs=date_code_runs)))
                 for year in range(this_year, this_year+3)}
 

--- a/stats/dashboard.py
+++ b/stats/dashboard.py
@@ -898,10 +898,12 @@ class ActivityStats(CommonSharedElements):
         """
         Number of activities with the budget_not_provided attribute for this year and the following 2 years.
 
-        Activities will be excluded if
-         i)  They end in the next 6 months
-         ii) At least 90% of the commitment transactions has been disbursed or expended
-             within or before the input year
+        Note activities excluded according if they meet the logic in _forwardlooking_exclude_in_calculations()
+
+        Input:
+          date_code_runs -- a date object for when this code is run
+        Returns:
+          dictionary containing years with binary value if this activity is current and has the budget_not_provided attribute
         """
         date_code_runs = date_code_runs if date_code_runs else self.now.date()
         this_year = int(date_code_runs.year)

--- a/stats/tests/test_budget_not_provided.py
+++ b/stats/tests/test_budget_not_provided.py
@@ -1,11 +1,17 @@
 from lxml import etree
 
-from collections import defaultdict, OrderedDict
-from stats.common.decorators import *
+from stats.dashboard import ActivityStats
 
+class MockActivityStats(ActivityStats):
+    def __init__(self, major_version='2'):
+        self.major_version = major_version
+        return super(MockActivityStats, self).__init__()
+
+    def _major_version(self):
+        return self.major_version
 
 def test_budget_not_provided_works():
-    activity_stats = ActivityStats()
+    activity_stats = MockActivityStats()
     activity_stats.element = etree.fromstring('''
             <iati-activity budget-not-provided="1">
             </iati-activity>
@@ -14,7 +20,7 @@ def test_budget_not_provided_works():
 
 
 def test_budget_not_provided_fails():
-    activity_stats = ActivityStats()
+    activity_stats = MockActivityStats()
     activity_stats.element = etree.fromstring('''
             <iati-activity>
             </iati-activity>
@@ -23,30 +29,9 @@ def test_budget_not_provided_fails():
 
 
 def test_budget_validation_bools():
-    activity_stats = ActivityStats()
+    activity_stats = MockActivityStats()
     activity_stats.element = etree.fromstring('''
             <iati-activity budget-not-provided="3">
             </iati-activity>
     ''')
     assert (len(activity_stats.element.findall('budget')) == 0)
-
-
-
-class CommonSharedElements(object):
-    blank = False
-
-
-class ActivityStats(CommonSharedElements):
-    """ Stats calculated on a single iati-activity. """
-    element = None
-    blank = False
-    strict = False # (Setting this to true will ignore values that don't follow the schema)
-    context = ''
-    comprehensiveness_current_activity_status = None
-    now = datetime.datetime.now()
-
-    def _budget_not_provided(self):
-        if self.element.attrib.get('budget-not-provided'):
-            return int(self.element.attrib.get('budget-not-provided'))
-        else:
-            return None


### PR DESCRIPTION
Importing the functions from `ActivityStats` for tests, tackling #148  

Investigating #150, `_forwardlooking_is_current()` and `_forwardlooking_exclude_in_calculations()` take into account the `activity-dates`, to make this clearer, I've added docs to the function explaining the link to excluded cases. 