### PR TITLE
Add missing humanitarian 5-digit sector code

### DIFF
--- a/stats/dashboard.py
+++ b/stats/dashboard.py
@@ -1226,7 +1226,7 @@ class ActivityStats(CommonSharedElements):
 
     @returns_numberdict
     def humanitarian(self):
-        humanitarian_sectors_dac_5_digit = ['72010', '72040', '72050', '73010', '74010']
+        humanitarian_sectors_dac_5_digit = ['72010', '72040', '72050', '73010', '74010', '74020']
         humanitarian_sectors_dac_3_digit = ['720', '730', '740']
 
         # logic around use of the @humanitarian attribute

--- a/stats/tests/test_humanitarian.py
+++ b/stats/tests/test_humanitarian.py
@@ -23,7 +23,7 @@ class MockActivityStats(ActivityStats):
     def _version(self):
         return self._major_version() + '.' + self._minor_version()
 
-HUMANITARIAN_SECTOR_CODES_5_DIGITS = [72010, 72040, 72050, 73010, 74010]
+HUMANITARIAN_SECTOR_CODES_5_DIGITS = [72010, 72040, 72050, 73010, 74010, 74020]
 HUMANITARIAN_SECTOR_CODES_3_DIGITS = [720, 730, 740]
 
 @pytest.mark.parametrize('version', ['2.02', '2.03'])


### PR DESCRIPTION
5-digit sector code `74020` (Multi-hazard response preparedness) was added in Jan 2018, and presumably should count as a humanitarian sector code.

There’s a corresponding update to make to the dashboard narrative, where it says:
> […] the use of DAC 5-digit sector codes between `72010` to `74010` inclusive […]